### PR TITLE
Use functools cache for python <3.9

### DIFF
--- a/feynman_path/diagram.py
+++ b/feynman_path/diagram.py
@@ -23,7 +23,7 @@ def _disp(svg, msg):
     display(DispWrap())
     return svg
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def render_cache(latex):
     return _disp(latextools.render_snippet(
             latex,


### PR DESCRIPTION
fixes #1 